### PR TITLE
Implements Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,32 +40,39 @@ src/
 ### Tecnologias e Dependências
 
 #### Framework Base
+
 - **.NET 9.0** - Framework principal da aplicação
 - **ASP.NET Core** - Framework web para APIs REST
 
 #### Banco de Dados
+
 - **Entity Framework Core 8.0** - ORM para acesso a dados
 - **Pomelo.EntityFrameworkCore.MySql** - Provider para MySQL
 - **MySQL 8.4** - Sistema de gerenciamento de banco de dados
 
 #### Arquitetura e Padrões
+
 - **MediatR** - Implementação do padrão Mediator para CQRS
 - **AutoMapper** - Mapeamento automático entre objetos
 - **FluentResults** - Tratamento de resultados de operações
 - **FluentValidation** - Validação de dados de entrada
 
 #### Autenticação e Segurança
+
 - **JWT Bearer Authentication** - Autenticação baseada em tokens JWT
 
 #### Documentação e Testes
+
 - **Swagger/OpenAPI** - Documentação interativa da API
 - **xUnit** - Framework de testes unitários
 - **AutoFixture** - Geração automática de dados para testes
 
 #### Logging e Monitoramento
+
 - **Serilog** - Sistema de logging estruturado
 
 #### Comunicação
+
 - **MailHog** - Servidor SMTP para desenvolvimento e testes de e-mail
 
 ### Estrutura de Pastas
@@ -92,10 +99,18 @@ fiap-soat-oficina-mecanica/
 ### Pré-requisitos
 
 #### Para execução com Docker (Recomendado)
+
 - **Docker Desktop** ou **Docker Engine** (versão 20.10+)
 - **Docker Compose** (versão 2.0+)
 
+#### Para execução com Kubernetes
+
+- **Kubernetes cluster** (minikube, kind, EKS, GKE, AKS, etc.)
+- **kubectl** (versão 1.25+)
+- **Kustomize** (incluído no kubectl 1.14+)
+
 #### Para desenvolvimento local
+
 - **.NET SDK 9.0** ou superior
 - **MySQL 8.0** ou superior
 - **Git** para controle de versão
@@ -133,6 +148,7 @@ dotnet run
 ```
 
 **Configuração de banco local:**
+
 ```json
 "ConnectionStrings": {
   "DefaultConnection": "server=localhost;port=3306;database=workshopdb;user=workshopuser;password=workshop123;SslMode=none;AllowPublicKeyRetrieval=True;"
@@ -140,6 +156,7 @@ dotnet run
 ```
 
 **Serviços disponíveis:**
+
 - API: https://localhost:7286 (HTTPS) ou http://localhost:5287 (HTTP)
 - MailHog: http://localhost:8025
 - MySQL: localhost:3306
@@ -152,11 +169,43 @@ docker compose -p "fiap-smart-mechanical-workshop" down
 docker compose -f docker-compose.dev.yml -p "fiap-smart-mechanical-workshop-dev" down
 ```
 
+### Opção 3: Deploy no Kubernetes
+
+Para deployar a aplicação em um cluster Kubernetes, utilize nossa infraestrutura configurada com Kustomize:
+
+```bash
+# Navegar para o diretório k8s
+cd k8s
+
+# Deploy para development
+./deploy.sh development
+
+# Deploy para staging
+./deploy.sh staging
+
+# Deploy para production
+./deploy.sh production
+
+# Verificar status dos serviços
+./status.sh development
+```
+
+**📖 Para instruções detalhadas de Kubernetes, consulte: [k8s/README.md](k8s/README.md)**
+
+A infraestrutura Kubernetes inclui:
+
+- **Multi-ambiente**: Development, Staging e Production
+- **Auto-scaling**: HPA baseado em CPU
+- **LoadBalancer**: Exposição externa automática
+- **Persistent Storage**: Para dados do MySQL
+- **Ingress**: HTTPS para produção
+- **Monitoramento**: Scripts de debug e status
+
 ## Gerenciamento de Migrations do Banco de Dados
 
 O projeto utiliza **Entity Framework Core** para gerenciar as migrations do banco de dados. Siga os passos abaixo para trabalhar com migrations:
 
-### Pré-requisitos
+### Pré-requisitos(Migrations)
 
 Instale a ferramenta global do Entity Framework (caso ainda não tenha):
 
@@ -175,6 +224,7 @@ dotnet ef migrations add NOME_DA_MIGRATION \
 ```
 
 **Parâmetros:**
+
 - `--project`: Indica onde estão as classes de contexto e migrations
 - `--startup-project`: Indica onde está o projeto de inicialização (API)
 
@@ -237,7 +287,7 @@ A aplicação utiliza **autenticação JWT (JSON Web Token)** para proteger todo
 
 | E-mail | Perfil | Senha |
 |--------|--------|-------|
-| joao.silva@email.com | Employee | Pa$$w0rd! |
+| <joao.silva@email.com> | Employee | Pa$$w0rd! |
 
 ### Exemplo de Requisição de Login
 
@@ -264,6 +314,7 @@ curl --location 'http://localhost:5180/auth/login' \
 ### Como Usar o Token
 
 #### No Swagger
+
 1. Faça login usando o endpoint `/auth/login`
 2. Copie o token retornado
 3. Clique no botão **"Authorize"** no topo da página do Swagger
@@ -271,6 +322,7 @@ curl --location 'http://localhost:5180/auth/login' \
 5. Todos os endpoints protegidos agora funcionarão automaticamente
 
 #### Em Requisições HTTP
+
 Adicione o header de autorização em todas as requisições:
 
 ```bash

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,430 @@
+# Kubernetes Infrastructure for Smart Mechanical Workshop
+
+Este diretório contém toda a configuração de infraestrutura Kubernetes para o projeto Smart Mechanical Workshop, utilizando **Kustomize** para gerenciamento de múltiplos ambientes.
+
+## 📋 Índice
+
+- [Arquitetura](#arquitetura)
+- [Estrutura de Arquivos](#estrutura-de-arquivos)
+- [Ambientes Configurados](#ambientes-configurados)
+- [Pré-requisitos](#pré-requisitos)
+- [Configuração por Ambiente](#configuração-por-ambiente)
+- [Deploy](#deploy)
+- [Acesso aos Serviços](#acesso-aos-serviços)
+- [Monitoramento e Debug](#monitoramento-e-debug)
+- [Scripts Utilitários](#scripts-utilitários)
+
+## 🏗️ Arquitetura
+
+A infraestrutura Kubernetes foi projetada seguindo as melhores práticas de DevOps e separação de ambientes:
+
+```
+┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│   Development   │    │     Staging     │    │   Production    │
+├─────────────────┤    ├─────────────────┤    ├─────────────────┤
+│ API (External)  │    │ API (External)  │    │ API (External)  │
+│ MySQL (External)│    │ MySQL (External)│    │ MySQL (Internal)│
+│ MailHog (Ext.)  │    │ MailHog (Ext.)  │    │ MailHog (Int.)  │
+└─────────────────┘    └─────────────────┘    └─────────────────┘
+```
+
+### Componentes
+
+- **API**: Aplicação .NET 9.0 principal
+- **MySQL 8.0**: Banco de dados principal
+- **MailHog**: Servidor SMTP para desenvolvimento/teste
+- **HPA**: Auto-scaling horizontal baseado em CPU
+- **LoadBalancer**: Exposição externa dos serviços (dev/staging)
+- **Ingress**: Roteamento HTTPS para produção
+
+## 📁 Estrutura de Arquivos
+
+```
+k8s/
+├── base/                           # Configurações base (reutilizáveis)
+│   ├── kustomization.yaml         # Kustomize base
+│   ├── namespace.yaml             # Namespace da aplicação
+│   ├── configmap.yaml             # Configurações da aplicação
+│   ├── secrets.yaml               # Senhas e chaves secretas
+│   ├── pvc.yaml                   # Persistent Volume para MySQL
+│   ├── mysql-deployment.yaml     # Deployment do MySQL
+│   ├── api-deployment.yaml       # Deployment da API
+│   ├── mailhog-deployment.yaml   # Deployment do MailHog
+│   ├── services.yaml             # Services (ClusterIP base)
+│   ├── hpa.yaml                  # Horizontal Pod Autoscaler
+│   └── ingress.yaml              # Ingress base
+├── overlays/                      # Configurações específicas por ambiente
+│   ├── development/
+│   │   └── kustomization.yaml    # Sobrescritas para desenvolvimento
+│   ├── staging/
+│   │   └── kustomization.yaml    # Sobrescritas para staging
+│   └── production/
+│       ├── kustomization.yaml    # Sobrescritas para produção
+│       └── ingress.yaml          # Ingress com HTTPS
+├── deploy.sh                     # Script de deploy automatizado
+├── status.sh                     # Script para verificar status dos serviços
+├── debug-api.sh                  # Script de debug para API
+└── deploy_instructions.md        # Instruções de deploy
+```
+
+## 🌍 Ambientes Configurados
+
+### Development
+- **Namespace**: `smart-mechanical-workshop-dev`
+- **Replicas**: 1 (API), 1 (MySQL)
+- **Exposição**: LoadBalancer para API, MySQL e MailHog
+- **HPA**: 1-3 replicas baseado em CPU
+- **Finalidade**: Desenvolvimento local e testes
+
+### Staging
+- **Namespace**: `smart-mechanical-workshop-staging`
+- **Replicas**: 2 (API), 1 (MySQL)
+- **Exposição**: LoadBalancer para API, MySQL e MailHog
+- **HPA**: 2-5 replicas baseado em CPU
+- **Finalidade**: Testes de integração e validação
+
+### Production
+- **Namespace**: `smart-mechanical-workshop-prod`
+- **Replicas**: 3 (API), 1 (MySQL)
+- **Exposição**: LoadBalancer apenas para API (MySQL e MailHog internos)
+- **HPA**: 3-20 replicas baseado em CPU
+- **Ingress**: HTTPS com certificados SSL
+- **Finalidade**: Ambiente de produção
+
+## 🔧 Pré-requisitos
+
+### Software Necessário
+- **Kubernetes cluster** (minikube, kind, EKS, GKE, AKS, etc.)
+- **kubectl** (versão 1.25+)
+- **Kustomize** (incluído no kubectl 1.14+)
+
+### Verificar Pré-requisitos
+```bash
+# Verificar cluster Kubernetes
+kubectl cluster-info
+
+# Verificar versão do kubectl
+kubectl version --client
+
+# Verificar Kustomize
+kubectl kustomize --help
+```
+
+### Configuração de Storage Class (se necessário)
+```bash
+# Verificar storage classes disponíveis
+kubectl get storageclass
+
+# Se não houver storage class padrão, configure uma
+# Exemplo para minikube:
+minikube addons enable default-storageclass
+```
+
+## ⚙️ Configuração por Ambiente
+
+### Imagens Docker
+
+| Ambiente | API Tag | DB Tag |
+|----------|---------|--------|
+| Development | `latest` | `latest` |
+| Staging | `staging-latest` | `staging-latest` |
+| Production | `v1.0.0` | `v1.0.0` |
+
+### Recursos Computacionais
+
+| Ambiente | API CPU | API Memory | MySQL CPU | MySQL Memory |
+|----------|---------|------------|-----------|--------------|
+| Development | 100m-500m | 256Mi-512Mi | 100m-250m | 256Mi-512Mi |
+| Staging | 200m-750m | 512Mi-1Gi | 100m-250m | 256Mi-512Mi |
+| Production | 200m-1000m | 512Mi-1Gi | 200m-500m | 512Mi-1Gi |
+
+### Configurações de Rede
+
+| Ambiente | API Port | MySQL Port | MailHog Port |
+|----------|----------|------------|--------------|
+| Development | 5180 (External) | 3306 (External) | 8025 (External) |
+| Staging | 5180 (External) | 3306 (External) | 8025 (External) |
+| Production | 5180 (External) | 3306 (Internal) | 8025 (Internal) |
+
+## 🚀 Deploy
+
+### Deploy Automatizado
+
+```bash
+# Tornar scripts executáveis
+chmod +x deploy.sh status.sh debug-api.sh
+
+# Deploy para development
+./deploy.sh development
+
+# Deploy para staging
+./deploy.sh staging
+
+# Deploy para production
+./deploy.sh production
+```
+
+### Deploy Manual com kubectl
+
+```bash
+# Development
+kubectl apply -k overlays/development/
+
+# Staging
+kubectl apply -k overlays/staging/
+
+# Production
+kubectl apply -k overlays/production/
+```
+
+### Verificar Deploy
+
+```bash
+# Verificar status com script
+./status.sh development
+
+# Verificar manualmente
+kubectl get all -n smart-mechanical-workshop-dev
+```
+
+## 🌐 Acesso aos Serviços
+
+### K8S Development
+
+Após o deploy, execute `./status.sh development` para obter as URLs:
+
+```bash
+# Exemplo de saída:
+🔗 API: http://203.0.113.10:5180
+❤️  Health: http://203.0.113.10:5180/health
+📧 MailHog: http://203.0.113.15:8025
+🗄️  MySQL: 203.0.113.20:3306
+```
+
+**Endpoints da API:**
+
+- **Swagger**: `http://<API-IP>:5180/swagger`
+- **Health Check**: `http://<API-IP>:5180/health`
+- **Login**: `POST http://<API-IP>:5180/auth/login`
+
+**MailHog Web Interface:**
+- **URL**: `http://<MAILHOG-IP>:8025`
+
+**Conexão MySQL:**
+
+```bash
+mysql -h <MYSQL-IP> -P 3306 -u workshopuser_dev -p
+# Senha: workshop123
+```
+
+### K8S Staging
+
+```bash
+./status.sh staging
+```
+
+URLs similares ao development com prefixo `staging-`.
+
+### K8S Production
+
+```bash
+./status.sh production
+```
+
+**Apenas API exposta externamente:**
+
+- **API**: `http://<API-IP>:5180`
+- **Ingress HTTPS**: `https://api.your-domain.com` (configurar DNS)
+
+## 📊 Monitoramento e Debug
+
+### Verificar Status dos Pods
+
+```bash
+# Status geral
+kubectl get pods -n smart-mechanical-workshop-dev
+
+# Detalhes de um pod específico
+kubectl describe pod <pod-name> -n smart-mechanical-workshop-dev
+
+# Logs da aplicação
+kubectl logs -f <pod-name> -n smart-mechanical-workshop-dev
+```
+
+### Logs em Tempo Real
+
+```bash
+# Logs da API
+kubectl logs -l app.kubernetes.io/name=smart-mechanical-workshop-api -n smart-mechanical-workshop-dev -f
+
+# Logs do MySQL
+kubectl logs -l app.kubernetes.io/name=mysql -n smart-mechanical-workshop-dev -f
+
+# Eventos do namespace
+kubectl get events -n smart-mechanical-workshop-dev --sort-by='.lastTimestamp'
+```
+
+### Debug da API
+
+```bash
+# Script automatizado de debug
+./debug-api.sh
+
+# Port forward para debug local (se necessário)
+kubectl port-forward svc/dev-api-service 5180:5180 -n smart-mechanical-workshop-dev
+```
+
+### Verificar Auto-scaling
+
+```bash
+# Status do HPA
+kubectl get hpa -n smart-mechanical-workshop-dev
+
+# Detalhes do auto-scaling
+kubectl describe hpa dev-api-hpa -n smart-mechanical-workshop-dev
+```
+
+## 🛠️ Scripts Utilitários
+
+### deploy.sh
+
+```bash
+./deploy.sh <environment>
+```
+
+- Deploy automatizado para ambiente específico
+- Aguarda LoadBalancer obter IP externo
+- Mostra URLs de acesso dos serviços
+
+### status.sh
+
+```bash
+./status.sh <environment>
+```
+
+- Verifica status de todos os serviços
+- Mostra URLs de acesso externo
+- Lista pods e seus estados
+
+### debug-api.sh
+
+```bash
+./debug-api.sh
+```
+- Debug completo da API
+- Logs atuais e anteriores
+- Descrição detalhada do pod
+- Status de ConfigMaps e Secrets
+
+## 🔧 Troubleshooting
+
+### Problemas Comuns
+
+#### Pod em CrashLoopBackOff
+
+```bash
+# Ver logs do pod
+kubectl logs <pod-name> -n <namespace> --previous
+
+# Verificar configurações
+kubectl describe pod <pod-name> -n <namespace>
+```
+
+#### LoadBalancer Pending
+
+```bash
+# Verificar se cluster suporta LoadBalancer
+kubectl get svc -n <namespace>
+
+# Para minikube, habilitar tunnel
+minikube tunnel
+```
+
+#### Erro de Conexão MySQL
+
+```bash
+# Verificar se MySQL está rodando
+kubectl get pods -l app.kubernetes.io/name=mysql -n <namespace>
+
+# Testar conexão interna
+kubectl exec -it <api-pod> -n <namespace> -- curl dev-mysql-service:3306
+```
+
+#### Imagem não encontrada
+
+```bash
+# Verificar se imagens existem no registry
+docker pull igortessaro/smart-mechanical-workshop-api:latest
+
+# Para minikube/kind, carregar imagem local
+minikube image load igortessaro/smart-mechanical-workshop-api:latest
+```
+
+### Limpeza Completa
+
+```bash
+# Deletar ambiente específico
+kubectl delete -k overlays/development/
+
+# Deletar namespace (remove tudo)
+kubectl delete namespace smart-mechanical-workshop-dev
+
+# Limpar recursos órfãos
+kubectl delete pv --all
+```
+
+## 📝 Configurações Avançadas
+
+### Configurar Ingress com HTTPS
+
+1. **Instalar cert-manager**:
+
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/cert-manager.yaml
+```
+
+2. **Configurar ClusterIssuer**:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@domain.com
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+```
+
+3. **Atualizar DNS** para apontar para o Ingress Controller
+
+### Configurar Monitoramento
+
+```bash
+# Instalar Prometheus e Grafana
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm install monitoring prometheus-community/kube-prometheus-stack
+```
+
+### Backup do MySQL
+
+```bash
+# Criar backup
+kubectl exec <mysql-pod> -n <namespace> -- mysqldump -u root -p<password> workshopdb > backup.sql
+
+# Restaurar backup
+kubectl exec -i <mysql-pod> -n <namespace> -- mysql -u root -p<password> workshopdb < backup.sql
+```
+
+## 📚 Referências
+
+- [Kustomize Documentation](https://kustomize.io/)
+- [Kubernetes Documentation](https://kubernetes.io/docs/)
+- [MySQL on Kubernetes](https://kubernetes.io/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/)
+- [HPA Documentation](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)

--- a/k8s/base/api-deployment.yaml
+++ b/k8s/base/api-deployment.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-deployment
+  labels:
+    app.kubernetes.io/name: smart-mechanical-workshop-api
+    app.kubernetes.io/component: api
+    app.kubernetes.io/version: "latest"
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: smart-mechanical-workshop-api
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: smart-mechanical-workshop-api
+        app.kubernetes.io/component: api
+        app.kubernetes.io/version: "latest"
+    spec:
+      containers:
+      - name: api
+        image: igortessaro/smart-mechanical-workshop-api:latest
+        ports:
+        - containerPort: 8080
+          name: http
+        env:
+        - name: ASPNETCORE_ENVIRONMENT
+          valueFrom:
+            configMapKeyRef:
+              name: smart-mechanical-workshop-config
+              key: ASPNETCORE_ENVIRONMENT
+        - name: ConnectionStrings__DefaultConnection
+          value: "server=$(DB_HOST);port=$(DB_PORT);database=$(MYSQL_DATABASE);user=$(MYSQL_USER);password=$(MYSQL_PASSWORD);SslMode=none;AllowPublicKeyRetrieval=True;"
+        - name: DB_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: smart-mechanical-workshop-config
+              key: DB_HOST
+        - name: DB_PORT
+          valueFrom:
+            configMapKeyRef:
+              name: smart-mechanical-workshop-config
+              key: DB_PORT
+        - name: MYSQL_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: smart-mechanical-workshop-config
+              key: MYSQL_DATABASE
+        - name: MYSQL_USER
+          valueFrom:
+            configMapKeyRef:
+              name: smart-mechanical-workshop-config
+              key: MYSQL_USER
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: smart-mechanical-workshop-secrets
+              key: MYSQL_PASSWORD
+        - name: Jwt__Key
+          valueFrom:
+            secretKeyRef:
+              name: smart-mechanical-workshop-secrets
+              key: JWT_KEY
+        - name: BaseUrl
+          valueFrom:
+            configMapKeyRef:
+              name: smart-mechanical-workshop-config
+              key: BASE_URL
+        - name: Email__SmtpHost
+          valueFrom:
+            configMapKeyRef:
+              name: smart-mechanical-workshop-config
+              key: SMTP_HOST
+        - name: Email__SmtpPort
+          valueFrom:
+            configMapKeyRef:
+              name: smart-mechanical-workshop-config
+              key: SMTP_PORT
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: smart-mechanical-workshop-config
+  namespace: smart-mechanical-workshop
+  labels:
+    app.kubernetes.io/name: smart-mechanical-workshop
+    app.kubernetes.io/component: config
+data:
+  ASPNETCORE_ENVIRONMENT: "Production"
+  DB_HOST: "mysql-service"
+  DB_PORT: "3306"
+  MYSQL_DATABASE: "workshopdb"
+  MYSQL_USER: "workshopuser"
+  SMTP_HOST: "mailhog-service"
+  SMTP_PORT: "1025"
+  BASE_URL: "https://your-domain.com"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-config
+  namespace: smart-mechanical-workshop
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/component: database
+data:
+  MYSQL_DATABASE: "workshopdb"
+  MYSQL_USER: "workshopuser"

--- a/k8s/base/hpa.yaml
+++ b/k8s/base/hpa.yaml
@@ -1,0 +1,45 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-hpa
+  namespace: smart-mechanical-workshop
+  labels:
+    app.kubernetes.io/name: smart-mechanical-workshop-api
+    app.kubernetes.io/component: autoscaler
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api-deployment
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 10
+        periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 15
+      - type: Pods
+        value: 2
+        periodSeconds: 60
+      selectPolicy: Max

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: smart-mechanical-workshop-ingress
+  namespace: smart-mechanical-workshop
+  labels:
+    app.kubernetes.io/name: smart-mechanical-workshop
+    app.kubernetes.io/component: ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod" # Se usando cert-manager
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - your-domain.com
+    - mailhog.your-domain.com
+    secretName: smart-mechanical-workshop-tls
+  rules:
+  - host: your-domain.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: api-service
+            port:
+              number: 80
+  - host: mailhog.your-domain.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: mailhog-service
+            port:
+              number: 8025

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- namespace.yaml
+- configmap.yaml
+- secrets.yaml
+- pvc.yaml
+- mysql-deployment.yaml
+- api-deployment.yaml
+- mailhog-deployment.yaml
+- services.yaml
+- hpa.yaml
+
+labels:
+- pairs:
+    app.kubernetes.io/part-of: smart-mechanical-workshop
+
+images:
+- name: igortessaro/smart-mechanical-workshop-api
+  newTag: latest
+- name: igortessaro/smart-mechanical-workshop-db
+  newTag: latest

--- a/k8s/base/mailhog-deployment.yaml
+++ b/k8s/base/mailhog-deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mailhog-deployment
+  namespace: smart-mechanical-workshop
+  labels:
+    app.kubernetes.io/name: mailhog
+    app.kubernetes.io/component: mail-testing
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mailhog
+      app.kubernetes.io/component: mail-testing
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mailhog
+        app.kubernetes.io/component: mail-testing
+    spec:
+      containers:
+      - name: mailhog
+        image: mailhog/mailhog:latest
+        ports:
+        - containerPort: 1025
+          name: smtp
+        - containerPort: 8025
+          name: web
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "100m"

--- a/k8s/base/mysql-deployment.yaml
+++ b/k8s/base/mysql-deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-deployment
+  namespace: smart-mechanical-workshop
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/component: database
+    app.kubernetes.io/version: "8.4"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate # MySQL doesn't support rolling updates with persistent storage
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mysql
+        app.kubernetes.io/component: database
+        app.kubernetes.io/version: "8.4"
+    spec:
+      containers:
+      - name: mysql
+        image: igortessaro/smart-mechanical-workshop-db:latest
+        ports:
+        - containerPort: 3306
+          name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: smart-mechanical-workshop-secrets
+              key: MYSQL_ROOT_PASSWORD
+        - name: MYSQL_DATABASE
+          valueFrom:
+            configMapKeyRef:
+              name: mysql-config
+              key: MYSQL_DATABASE
+        - name: MYSQL_USER
+          valueFrom:
+            configMapKeyRef:
+              name: mysql-config
+              key: MYSQL_USER
+        - name: MYSQL_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: smart-mechanical-workshop-secrets
+              key: MYSQL_PASSWORD
+        volumeMounts:
+        - name: mysql-storage
+          mountPath: /var/lib/mysql
+        livenessProbe:
+          exec:
+            command:
+            - mysqladmin
+            - ping
+            - -h
+            - localhost
+            - -u
+            - root
+            - -p$(MYSQL_ROOT_PASSWORD)
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          exec:
+            command:
+            - mysqladmin
+            - ping
+            - -h
+            - localhost
+            - -u
+            - root
+            - -p$(MYSQL_ROOT_PASSWORD)
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+      volumes:
+      - name: mysql-storage
+        persistentVolumeClaim:
+          claimName: mysql-pvc

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: smart-mechanical-workshop
+  labels:
+    name: smart-mechanical-workshop
+    app.kubernetes.io/name: smart-mechanical-workshop
+    app.kubernetes.io/instance: production

--- a/k8s/base/pvc.yaml
+++ b/k8s/base/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pvc
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/component: storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/k8s/base/secrets.yaml
+++ b/k8s/base/secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: smart-mechanical-workshop-secrets
+  namespace: smart-mechanical-workshop
+  labels:
+    app.kubernetes.io/name: smart-mechanical-workshop
+    app.kubernetes.io/component: secrets
+type: Opaque
+data:
+  # Base64 encoded values - replace with your actual encoded secrets
+  JWT_KEY: eW91ci12ZXJ5LXNlY3VyZS1hbmQtbG9uZy1rZXktMTIzNDU2Nzg5MA== # your-very-secure-and-long-key-1234567890
+  MYSQL_ROOT_PASSWORD: cm9vdHBhc3N3b3Jk # rootpassword
+  MYSQL_PASSWORD: d29ya3Nob3AxMjM= # workshop123

--- a/k8s/base/services.yaml
+++ b/k8s/base/services.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-service
+  labels:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/component: database
+spec:
+  type: LoadBalancer # MySQL exposto externamente (apenas dev)
+  ports:
+  - port: 3306
+    targetPort: 3306
+    name: mysql
+  selector:
+    app.kubernetes.io/name: mysql
+    app.kubernetes.io/component: database
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service
+  labels:
+    app.kubernetes.io/name: smart-mechanical-workshop-api
+    app.kubernetes.io/component: api
+spec:
+  type: LoadBalancer  # API exposta externamente
+  ports:
+  - port: 80
+    targetPort: 8080
+    name: http
+  selector:
+    app.kubernetes.io/name: smart-mechanical-workshop-api
+    app.kubernetes.io/component: api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mailhog-service
+  labels:
+    app.kubernetes.io/name: mailhog
+    app.kubernetes.io/component: mail-testing
+spec:
+  type: LoadBalancer  # MailHog exposto externamente (apenas dev)
+  ports:
+  - port: 1025
+    targetPort: 1025
+    name: smtp
+  - port: 8025
+    targetPort: 8025
+    name: web
+  selector:
+    app.kubernetes.io/name: mailhog
+    app.kubernetes.io/component: mail-testing

--- a/k8s/base/services.yaml
+++ b/k8s/base/services.yaml
@@ -25,7 +25,7 @@ metadata:
 spec:
   type: LoadBalancer  # API exposta externamente
   ports:
-  - port: 80
+  - port: 5180
     targetPort: 8080
     name: http
   selector:

--- a/k8s/debug-api.sh
+++ b/k8s/debug-api.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+NAMESPACE="smart-mechanical-workshop-dev"
+
+echo "🔍 Debugging API deployment in $NAMESPACE"
+echo ""
+
+# Get pod name
+POD_NAME=$(kubectl get pods -n $NAMESPACE | grep "dev-api-deployment" | awk '{print $1}' | head -1)
+
+if [ -z "$POD_NAME" ]; then
+    echo "❌ No API pod found"
+    exit 1
+fi
+
+echo "📦 Pod: $POD_NAME"
+echo ""
+
+echo "📊 Pod Status:"
+kubectl get pod $POD_NAME -n $NAMESPACE -o wide
+
+echo ""
+echo "📋 Pod Description:"
+kubectl describe pod $POD_NAME -n $NAMESPACE
+
+echo ""
+echo "📝 Current Logs:"
+kubectl logs $POD_NAME -n $NAMESPACE --tail=50
+
+echo ""
+echo "📝 Previous Logs (if available):"
+kubectl logs $POD_NAME -n $NAMESPACE --previous --tail=50 2>/dev/null || echo "No previous logs available"
+
+echo ""
+echo "🔗 Services:"
+kubectl get svc -n $NAMESPACE
+
+echo ""
+echo "💾 ConfigMaps:"
+kubectl get configmap -n $NAMESPACE
+
+echo ""
+echo "🔐 Secrets:"
+kubectl get secrets -n $NAMESPACE

--- a/k8s/deploy.sh
+++ b/k8s/deploy.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+ENVIRONMENT=${1:-development}
+
+if [[ ! "$ENVIRONMENT" =~ ^(development|staging|production)$ ]]; then
+    echo "❌ Invalid environment. Use: development, staging, or production"
+    exit 1
+fi
+
+echo "🚀 Deploying Smart Mechanical Workshop to $ENVIRONMENT environment..."
+
+# Apply the specific environment overlay
+kubectl apply -k overlays/$ENVIRONMENT/
+
+echo "✅ Deployment to $ENVIRONMENT completed!"
+
+# Get the correct namespace suffix
+case $ENVIRONMENT in
+    development) NS_SUFFIX="dev" ;;
+    staging) NS_SUFFIX="staging" ;;
+    production) NS_SUFFIX="prod" ;;
+esac
+
+echo "📊 Check status with: kubectl get all -n smart-mechanical-workshop-$NS_SUFFIX"
+
+# Show some useful commands
+echo ""
+echo "🔧 Useful commands:"
+echo "  kubectl get all -n smart-mechanical-workshop-$NS_SUFFIX"
+echo "  kubectl logs -l app.kubernetes.io/name=smart-mechanical-workshop-api -n smart-mechanical-workshop-$NS_SUFFIX"
+echo "  kubectl get hpa -n smart-mechanical-workshop-$NS_SUFFIX"

--- a/k8s/deploy_instructions.md
+++ b/k8s/deploy_instructions.md
@@ -1,0 +1,23 @@
+# Tornar o script executável
+chmod +x k8s/deploy.sh
+
+# Deploy para development
+./k8s/deploy.sh development
+# ou
+kubectl apply -k k8s/overlays/development/
+
+# Deploy para staging
+./k8s/deploy.sh staging
+# ou
+kubectl apply -k k8s/overlays/staging/
+
+# Deploy para production
+./k8s/deploy.sh production
+# ou
+kubectl apply -k k8s/overlays/production/
+
+# Ver o que será aplicado (dry-run)
+kubectl kustomize k8s/overlays/development/
+
+# Deletar um ambiente
+kubectl delete -k k8s/overlays/development/

--- a/k8s/overlays/development/kustomization.yaml
+++ b/k8s/overlays/development/kustomization.yaml
@@ -1,0 +1,106 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: smart-mechanical-workshop-dev
+
+resources:
+- ../../base
+
+namePrefix: dev-
+
+labels:
+- pairs:
+    environment: development
+
+images:
+- name: igortessaro/smart-mechanical-workshop-api
+  newTag: latest
+- name: igortessaro/smart-mechanical-workshop-db
+  newTag: latest
+
+patches:
+- patch: |-
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: smart-mechanical-workshop-config
+    data:
+      ASPNETCORE_ENVIRONMENT: "Development"
+      BASE_URL: "http://localhost:5180"
+      DB_HOST: "dev-mysql-service"
+      DB_PORT: "3306"
+      MYSQL_DATABASE: "workshopdb_dev"
+      MYSQL_USER: "workshopuser_dev"
+      SMTP_HOST: "dev-mailhog-service"
+      SMTP_PORT: "1025"
+  target:
+    kind: ConfigMap
+    name: smart-mechanical-workshop-config
+- patch: |-
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: api-service
+    spec:
+      type: LoadBalancer
+  target:
+    kind: Service
+    name: api-service
+- patch: |-
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: mailhog-service
+    spec:
+      type: LoadBalancer
+  target:
+    kind: Service
+    name: mailhog-service
+- patch: |-
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: mysql-service
+    spec:
+      type: LoadBalancer
+  target:
+    kind: Service
+    name: mysql-service
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: api-deployment
+    spec:
+      replicas: 1
+      template:
+        spec:
+          containers:
+          - name: api
+            env:
+            - name: ConnectionStrings__DefaultConnection
+              value: "server=dev-mysql-service;port=3306;database=workshopdb_dev;user=workshopuser_dev;password=workshop123;SslMode=none;AllowPublicKeyRetrieval=True;"
+  target:
+    kind: Deployment
+    name: api-deployment
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: mysql-deployment
+    spec:
+      replicas: 1
+  target:
+    kind: Deployment
+    name: mysql-deployment
+- patch: |-
+    apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    metadata:
+      name: api-hpa
+    spec:
+      minReplicas: 1
+      maxReplicas: 3
+  target:
+    kind: HorizontalPodAutoscaler
+    name: api-hpa

--- a/k8s/overlays/development/kustomization.yaml
+++ b/k8s/overlays/development/kustomization.yaml
@@ -29,8 +29,8 @@ patches:
       BASE_URL: "http://localhost:5180"
       DB_HOST: "dev-mysql-service"
       DB_PORT: "3306"
-      MYSQL_DATABASE: "workshopdb_dev"
-      MYSQL_USER: "workshopuser_dev"
+      MYSQL_DATABASE: "workshopdb"
+      MYSQL_USER: "workshopuser"
       SMTP_HOST: "dev-mailhog-service"
       SMTP_PORT: "1025"
   target:
@@ -79,7 +79,7 @@ patches:
           - name: api
             env:
             - name: ConnectionStrings__DefaultConnection
-              value: "server=dev-mysql-service;port=3306;database=workshopdb_dev;user=workshopuser_dev;password=workshop123;SslMode=none;AllowPublicKeyRetrieval=True;"
+              value: "server=dev-mysql-service;port=3306;database=workshopdb;user=workshopuser;password=workshop123;SslMode=none;AllowPublicKeyRetrieval=True;"
   target:
     kind: Deployment
     name: api-deployment

--- a/k8s/overlays/production/ingress.yaml
+++ b/k8s/overlays/production/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: smart-mechanical-workshop-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - api.your-domain.com
+    secretName: smart-mechanical-workshop-tls
+  rules:
+  - host: api.your-domain.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: api-service
+            port:
+              number: 80

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -1,0 +1,101 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: smart-mechanical-workshop-prod
+
+resources:
+- ../../base
+- ingress.yaml
+
+namePrefix: prod-
+
+labels:
+- pairs:
+    environment: production
+
+images:
+- name: igortessaro/smart-mechanical-workshop-api
+  newTag: v1.0.0
+- name: igortessaro/smart-mechanical-workshop-db
+  newTag: v1.0.0
+
+patches:
+- patch: |-
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: smart-mechanical-workshop-config
+    data:
+      ASPNETCORE_ENVIRONMENT: "Production"
+      BASE_URL: "https://api.your-domain.com"
+      DB_HOST: "prod-mysql-service"
+      DB_PORT: "3306"
+      MYSQL_DATABASE: "workshopdb"
+      MYSQL_USER: "workshopuser"
+      SMTP_HOST: "prod-mailhog-service"
+      SMTP_PORT: "1025"
+  target:
+    kind: ConfigMap
+    name: smart-mechanical-workshop-config
+- patch: |-
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: api-service
+    spec:
+      type: LoadBalancer
+  target:
+    kind: Service
+    name: api-service
+- patch: |-
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: mailhog-service
+    spec:
+      type: ClusterIP
+  target:
+    kind: Service
+    name: mailhog-service
+- patch: |-
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: mysql-service
+    spec:
+      type: ClusterIP
+  target:
+    kind: Service
+    name: mysql-service
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: api-deployment
+    spec:
+      replicas: 3
+      template:
+        spec:
+          containers:
+          - name: api
+            resources:
+              requests:
+                memory: "512Mi"
+                cpu: "200m"
+              limits:
+                memory: "1Gi"
+                cpu: "1000m"
+  target:
+    kind: Deployment
+    name: api-deployment
+- patch: |-
+    apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    metadata:
+      name: api-hpa
+    spec:
+      minReplicas: 3
+      maxReplicas: 20
+  target:
+    kind: HorizontalPodAutoscaler
+    name: api-hpa

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -1,0 +1,89 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: smart-mechanical-workshop-staging
+
+resources:
+- ../../base
+
+namePrefix: staging-
+
+labels:
+- pairs:
+    environment: staging
+
+images:
+- name: igortessaro/smart-mechanical-workshop-api
+  newTag: staging-latest
+- name: igortessaro/smart-mechanical-workshop-db
+  newTag: staging-latest
+
+patches:
+- patch: |-
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: smart-mechanical-workshop-config
+    data:
+      ASPNETCORE_ENVIRONMENT: "Staging"
+      BASE_URL: "https://staging-api.your-domain.com"
+      DB_HOST: "staging-mysql-service"
+      DB_PORT: "3306"
+      MYSQL_DATABASE: "workshopdb_staging"
+      MYSQL_USER: "workshopuser_staging"
+      SMTP_HOST: "staging-mailhog-service"
+      SMTP_PORT: "1025"
+  target:
+    kind: ConfigMap
+    name: smart-mechanical-workshop-config
+- patch: |-
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: api-service
+    spec:
+      type: LoadBalancer
+  target:
+    kind: Service
+    name: api-service
+- patch: |-
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: mailhog-service
+    spec:
+      type: LoadBalancer
+  target:
+    kind: Service
+    name: mailhog-service
+- patch: |-
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: mysql-service
+    spec:
+      type: LoadBalancer
+  target:
+    kind: Service
+    name: mysql-service
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: api-deployment
+    spec:
+      replicas: 2
+  target:
+    kind: Deployment
+    name: api-deployment
+- patch: |-
+    apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    metadata:
+      name: api-hpa
+    spec:
+      minReplicas: 2
+      maxReplicas: 5
+  target:
+    kind: HorizontalPodAutoscaler
+    name: api-hpa

--- a/k8s/status.sh
+++ b/k8s/status.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+ENVIRONMENT=${1:-development}
+
+case $ENVIRONMENT in
+    development) NS_SUFFIX="dev" ;;
+    staging) NS_SUFFIX="staging" ;;
+    production) NS_SUFFIX="prod" ;;
+esac
+
+NAMESPACE="smart-mechanical-workshop-$NS_SUFFIX"
+
+echo "🌐 Service Status for $ENVIRONMENT environment"
+echo "=============================================="
+
+# Get all services
+kubectl get svc -n $NAMESPACE
+
+echo ""
+echo "🔗 External Access URLs:"
+echo "========================"
+
+# API Service
+API_INFO=$(kubectl get svc ${NS_SUFFIX}-api-service -n $NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}:{.spec.ports[0].port}' 2>/dev/null)
+if [ ! -z "$API_INFO" ] && [ "$API_INFO" != ":" ]; then
+    echo "🔗 API: http://$API_INFO"
+    echo "❤️  Health: http://$API_INFO/health"
+else
+    echo "🔗 API: External IP pending..."
+fi
+
+# MailHog for development and staging
+if [ "$ENVIRONMENT" == "development" ] || [ "$ENVIRONMENT" == "staging" ]; then
+    MAILHOG_INFO=$(kubectl get svc ${NS_SUFFIX}-mailhog-service -n $NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}:{.spec.ports[1].port}' 2>/dev/null)
+    if [ ! -z "$MAILHOG_INFO" ] && [ "$MAILHOG_INFO" != ":" ]; then
+        echo "📧 MailHog: http://$MAILHOG_INFO"
+    else
+        echo "📧 MailHog: External IP pending..."
+    fi
+fi
+
+# MySQL for development and staging
+if [ "$ENVIRONMENT" == "development" ] || [ "$ENVIRONMENT" == "staging" ]; then
+    MYSQL_INFO=$(kubectl get svc ${NS_SUFFIX}-mysql-service -n $NAMESPACE -o jsonpath='{.status.loadBalancer.ingress[0].ip}:{.spec.ports[0].port}' 2>/dev/null)
+    if [ ! -z "$MYSQL_INFO" ] && [ "$MYSQL_INFO" != ":" ]; then
+        echo "🗄️  MySQL: $MYSQL_INFO"
+        echo "   Connect with: mysql -h $(echo $MYSQL_INFO | cut -d: -f1) -P $(echo $MYSQL_INFO | cut -d: -f2) -u workshopuser_${ENVIRONMENT:0:3} -p"
+    else
+        echo "🗄️  MySQL: External IP pending..."
+    fi
+fi
+
+# Production notes
+if [ "$ENVIRONMENT" == "production" ]; then
+    echo "🔒 MailHog and MySQL are internal-only in production"
+fi
+
+echo ""
+echo "📊 Pod Status:"
+kubectl get pods -n $NAMESPACE


### PR DESCRIPTION
This pull request introduces a comprehensive Kubernetes deployment setup for the Smart Mechanical Workshop application, along with significant improvements to the documentation to support multi-environment deployments (development, staging, production). The changes include new Kubernetes manifests (deployments, services, ingress, config, secrets, storage, and autoscaling), helper scripts for deployment and debugging, and expanded README instructions for Kubernetes usage.

**Kubernetes Infrastructure:**

* Added full Kubernetes base manifests in the `k8s/base/` directory, including:
  - Deployments for API (`api-deployment.yaml`), MySQL (`mysql-deployment.yaml`), and MailHog (`mailhog-deployment.yaml`) [[1]](diffhunk://#diff-737fad09991f784e2b59f27a754d00f9bd7f628e67be444154f34fe5b15085e3R1-R108) [[2]](diffhunk://#diff-bc93cc8aff3befb5cb0e792505e527bd524fa8ae7bff510c6a81a1e03c4e0808R1-R93) [[3]](diffhunk://#diff-d2d442560417233ac914cf2f2c70d0d662a45ac865a86c222baba2faca2fc564R1-R35)
  - Services for API, MySQL, and MailHog (`services.yaml`)
  - Ingress for HTTPS routing and external access (`ingress.yaml`)
  - ConfigMaps and Secrets for environment configuration and sensitive data (`configmap.yaml`, `secrets.yaml`) [[1]](diffhunk://#diff-55448652decfb31a38fca0f79b981156292801c4704baadf057a01667e78353cR1-R29) [[2]](diffhunk://#diff-fbd087c70f6777d9274d28f3abc15382633a5eef770ad1d3915b54725d8fd7d6R1-R14)
  - Persistent storage for MySQL (`pvc.yaml`)
  - Horizontal Pod Autoscaler for API (`hpa.yaml`)
  - Namespace definition for environment isolation (`namespace.yaml`)
  - Kustomization file for resource aggregation and image management (`kustomization.yaml`)

**Deployment and Debugging Scripts:**

* Added `deploy.sh` for automated multi-environment deployment using Kustomize overlays, and a debugging script for API pods (`debug-api.sh`). [[1]](diffhunk://#diff-9a5bd6227b03d406b70177c1fe54c219bbf10215024edfeba971022180b4ddabR1-R33) [[2]](diffhunk://#diff-f5a66d0905ea3fd4b5abf96817836a21625a1d9c9607b90d549aaedc086100d7R1-R44)
* Added deployment instructions in `deploy_instructions.md`.

**Documentation Updates:**

* Expanded `README.md`:
  - Added Kubernetes as a supported deployment option, with prerequisites and usage instructions [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R102-R113) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172-R208)
  - Updated technology stack and clarified service endpoints [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R43-R75) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R151-R159)
  - Improved sections on authentication and usage examples [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L240-R290) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R317-R325)
  - Clarified migration management instructions

These changes enable robust, scalable, and secure deployments of the application across multiple environments, with clear operational and developer guidance.

**References:** [[1]](diffhunk://#diff-737fad09991f784e2b59f27a754d00f9bd7f628e67be444154f34fe5b15085e3R1-R108) [[2]](diffhunk://#diff-bc93cc8aff3befb5cb0e792505e527bd524fa8ae7bff510c6a81a1e03c4e0808R1-R93) [[3]](diffhunk://#diff-d2d442560417233ac914cf2f2c70d0d662a45ac865a86c222baba2faca2fc564R1-R35) [[4]](diffhunk://#diff-ce521e94b209a1065a48472c69bfcbad9e1a8f3da6a55691ec92c4a4e881ecfeR1-R53) [[5]](diffhunk://#diff-69f06cb699db502abadf560de482bba252396f0096bb3b8cda3aa9c7b815d499R1-R40) [[6]](diffhunk://#diff-55448652decfb31a38fca0f79b981156292801c4704baadf057a01667e78353cR1-R29) [[7]](diffhunk://#diff-fbd087c70f6777d9274d28f3abc15382633a5eef770ad1d3915b54725d8fd7d6R1-R14) [[8]](diffhunk://#diff-9e3be4c763751d5e35814ab41a23be589ce9a73d275a76c580071a6d4aef21feR1-R13) [[9]](diffhunk://#diff-a847c2ede802162319596e463696415abf07cbea943bbd70f2f3835df69312bfR1-R45) [[10]](diffhunk://#diff-709511397c7796b838daf89fc7df4c695e770e1bbea3732678ee79acede89a74R1-R8) [[11]](diffhunk://#diff-e0d0539019e0cfaaed1c69363edafcf4716a7876d5a6f7df477e66cc21424c1cR1-R23) [[12]](diffhunk://#diff-9a5bd6227b03d406b70177c1fe54c219bbf10215024edfeba971022180b4ddabR1-R33) [[13]](diffhunk://#diff-f5a66d0905ea3fd4b5abf96817836a21625a1d9c9607b90d549aaedc086100d7R1-R44) [[14]](diffhunk://#diff-5db73ffd52a9d9e04af18a9b8eec4950ed17f5fcf6c888ceb73475c84d15d415R1-R23) [[15]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R102-R113) [[16]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172-R208) [[17]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R43-R75) [[18]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R151-R159) [[19]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L240-R290) [[20]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R317-R325) [[21]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R227)